### PR TITLE
Refine mod_mosquitto Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,11 +9,11 @@ mosquitto_events.o \
 mosquitto_utils.o \
 mosquitto_mosq.o
 MODCFLAGS = -Wall -Werror
-MODLDFLAGS =
+MODLDFLAGS = -lssl -lcrypto
 
 CC = gcc
 CFLAGS = -fPIC -g -ggdb -I/usr/include `pkg-config --cflags freeswitch` $(MODCFLAGS) -std=c11 -O2
-LDFLAGS = `pkg-config --libs freeswitch` -lmosquitto -lssl -lcrypto -lpthread -lrt $(MODLDFLAGS)
+LDFLAGS = `pkg-config --libs freeswitch` -lmosquitto -lpthread -lrt $(MODLDFLAGS)
 
 .PHONY: all
 all: $(MODNAME)


### PR DESCRIPTION
## Summary
- specify SSL/Crypto libraries via MODLDFLAGS
- streamline linker flags for mosquitto module

## Testing
- `make clean`
- `make` *(fails: switch.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68adc3c1724c83229c858c748c18d31b